### PR TITLE
feat(Networks): add support for Stability Testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npx -p @tradetrust-tt/tradetrust-cli tradetrust <arguments>
 | xdcapothem         | 51       | Test       |
 | hederamainet       | 295      | Production |
 | hederatestnet      | 296      | Test       |
+| stabilitytestnet   | 20180427 | Test       |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1512,378 +1512,388 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
-      "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "requires": {
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/constants": "^5.4.0",
-        "@ethersproject/hash": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
-      "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/networks": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/transactions": "^5.4.0",
-        "@ethersproject/web": "^5.4.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
-      "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
-      "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/rlp": "^5.4.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
-      "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
-      "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
-      "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "bn.js": "^4.11.9"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "bn.js": "^5.2.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        }
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-      "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "requires": {
-        "@ethersproject/logger": "^5.4.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
-      "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.4.0"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
-      "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "requires": {
-        "@ethersproject/abi": "^5.4.0",
-        "@ethersproject/abstract-provider": "^5.4.0",
-        "@ethersproject/abstract-signer": "^5.4.0",
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/constants": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/transactions": "^5.4.0"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
-      "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.4.0",
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
-      "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.4.0",
-        "@ethersproject/basex": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/pbkdf2": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/sha2": "^5.4.0",
-        "@ethersproject/signing-key": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0",
-        "@ethersproject/transactions": "^5.4.0",
-        "@ethersproject/wordlists": "^5.4.0"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
-      "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.4.0",
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/hdnode": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/pbkdf2": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/random": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0",
-        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
-      "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "js-sha3": "0.5.7"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        }
+        "@ethersproject/bytes": "^5.7.0",
+        "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
-      "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
     },
     "@ethersproject/networks": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
-      "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "requires": {
-        "@ethersproject/logger": "^5.4.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
-      "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/sha2": "^5.4.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
-      "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "requires": {
-        "@ethersproject/logger": "^5.4.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.5.tgz",
-      "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.4.0",
-        "@ethersproject/abstract-signer": "^5.4.0",
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/basex": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/constants": "^5.4.0",
-        "@ethersproject/hash": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/networks": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/random": "^5.4.0",
-        "@ethersproject/rlp": "^5.4.0",
-        "@ethersproject/sha2": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0",
-        "@ethersproject/transactions": "^5.4.0",
-        "@ethersproject/web": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
     },
     "@ethersproject/random": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
-      "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
-      "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
-      "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
-      "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "bn.js": "^4.11.9",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        }
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/sha2": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
-      "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/constants": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "requires": {
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/constants": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/rlp": "^5.4.0",
-        "@ethersproject/signing-key": "^5.4.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "@ethersproject/units": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
-      "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/constants": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
-      "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.4.0",
-        "@ethersproject/abstract-signer": "^5.4.0",
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/hash": "^5.4.0",
-        "@ethersproject/hdnode": "^5.4.0",
-        "@ethersproject/json-wallets": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/random": "^5.4.0",
-        "@ethersproject/signing-key": "^5.4.0",
-        "@ethersproject/transactions": "^5.4.0",
-        "@ethersproject/wordlists": "^5.4.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "requires": {
-        "@ethersproject/base64": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
-      "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "requires": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/hash": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@govtechsg/jsonld": {
@@ -7158,40 +7168,40 @@
       }
     },
     "ethers": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
-      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "requires": {
-        "@ethersproject/abi": "5.4.1",
-        "@ethersproject/abstract-provider": "5.4.1",
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/base64": "5.4.0",
-        "@ethersproject/basex": "5.4.0",
-        "@ethersproject/bignumber": "5.4.2",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/contracts": "5.4.1",
-        "@ethersproject/hash": "5.4.0",
-        "@ethersproject/hdnode": "5.4.0",
-        "@ethersproject/json-wallets": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/networks": "5.4.2",
-        "@ethersproject/pbkdf2": "5.4.0",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/providers": "5.4.5",
-        "@ethersproject/random": "5.4.0",
-        "@ethersproject/rlp": "5.4.0",
-        "@ethersproject/sha2": "5.4.0",
-        "@ethersproject/signing-key": "5.4.0",
-        "@ethersproject/solidity": "5.4.0",
-        "@ethersproject/strings": "5.4.0",
-        "@ethersproject/transactions": "5.4.0",
-        "@ethersproject/units": "5.4.0",
-        "@ethersproject/wallet": "5.4.0",
-        "@ethersproject/web": "5.4.0",
-        "@ethersproject/wordlists": "5.4.0"
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "ethers-aws-kms-signer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,11 +1886,6 @@
         "@ethersproject/strings": "^5.4.0"
       }
     },
-    "@govtechsg/document-store": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@govtechsg/document-store/-/document-store-2.6.1.tgz",
-      "integrity": "sha512-Jr8dGyr8wBXMOSbUURoYfmz9jKiK2ntbjEYyI06pze6jzyiYLZXcepKVyjNk9PC/mLIlDCZgQWmre7ixBZWWjQ=="
-    },
     "@govtechsg/jsonld": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@govtechsg/jsonld/-/jsonld-0.1.1.tgz",
@@ -1909,14 +1904,6 @@
       "requires": {
         "debug": "^4.3.1",
         "node-forge": "^0.10.0"
-      }
-    },
-    "@govtechsg/token-registry": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@govtechsg/token-registry/-/token-registry-4.1.7.tgz",
-      "integrity": "sha512-OGv8IfRvYs7MR9SzUeTZElsBhuvXeIvob7zw3vD24vL4hzeNNjOOBEeoSuAkpqt8du6bbtKTCmPe5tfoJXhTAA==",
-      "requires": {
-        "@typechain/ethers-v5": "~10.0.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -3066,9 +3053,9 @@
       "dev": true
     },
     "@tradetrust-tt/dnsprove": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.8.1.tgz",
-      "integrity": "sha512-3ASF0SN8SwhS0tzUBMwNjd4vgzD+AD8BOVq5C53aUMbX0zJ98xrn7I4medg03ozOeNPaN4AcqirA/lBDDnn7dA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.10.0.tgz",
+      "integrity": "sha512-Swco0gqnJ5mYnLcD2uOTo36ieA+X3GioFhVE7mhA1YXKLrF3D8k8QRFV9yTsnxu8ybmoXwJUlwmOD8w6zxtK5A==",
       "requires": {
         "axios": "^0.21.1",
         "debug": "^4.3.1",
@@ -3081,9 +3068,9 @@
       "integrity": "sha512-wMTQkZ4FNzYvlWwaeKCHuV8fYxw+kefI38dTMHY5fpV3B5oaapePFGKHDs+4IrV1ZVFHQbqR/r/MP7dNwwjJDA=="
     },
     "@tradetrust-tt/token-registry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/token-registry/-/token-registry-4.5.0.tgz",
-      "integrity": "sha512-Xr8Uq5m6HRnePg8EwOMivkBObafKSt5TGkOXEliMHIMZzlQauWBgadkzBJhGYQMZ2hM1LN2iH1sgd207jEzYPA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/token-registry/-/token-registry-4.6.0.tgz",
+      "integrity": "sha512-1123HA/q+2ej5/YjQ4ZCekE6FQLxI0eVi9gVACIPV5yOADme1sGyxXPMhP7EDE5qB1taLjTbz2hoqD6COfzP1w==",
       "requires": {
         "@typechain/ethers-v5": "~10.0.0"
       }
@@ -3524,14 +3511,14 @@
       }
     },
     "@tradetrust-tt/tradetrust-config": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tradetrust-config/-/tradetrust-config-1.9.0.tgz",
-      "integrity": "sha512-KKtCZsEwP/TheKHank2HRfGicWUL8O/CdcvdzHavi5J5gkEgxkYenSwXDvbe03rWVpqyTPBe+3dO2HTjQwhdAA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tradetrust-config/-/tradetrust-config-1.11.0.tgz",
+      "integrity": "sha512-5daAix7FREEKMIUC40AQvLZ2Bx/khjPjFTqiC9J2owxnuVZKETvz9O7DVPlH19Xp+JV/S6wgEJCLtjwkTHme4Q==",
       "requires": {
-        "ajv": "^8.11.2",
+        "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "junk": "3.1.0",
-        "typedoc": "^0.23.28"
+        "typedoc": "^0.25.4"
       },
       "dependencies": {
         "ajv": {
@@ -3556,30 +3543,470 @@
       }
     },
     "@tradetrust-tt/tt-verify": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tt-verify/-/tt-verify-8.4.0.tgz",
-      "integrity": "sha512-+Cg7kUJ+csnhsc9YWjSQQkmhIR7EpDTz4gy+AwyYSuQ2ie+2A4SL/AWkwVz8zHZxBXXgqySM65pI37fQJuEq4g==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tt-verify/-/tt-verify-8.7.0.tgz",
+      "integrity": "sha512-9hMwQ1ByYP4BSpD++oMaS0emI7DKfV/vpoB9P1nTRUWv95EKk+K8Y6+L4DRc3jphRtaS5Ky/w52/51dEZMq7fA==",
       "requires": {
-        "@govtechsg/document-store": "^2.2.3",
-        "@govtechsg/token-registry": "^4.1.7",
-        "@tradetrust-tt/dnsprove": "^2.7.0",
+        "@tradetrust-tt/dnsprove": "^2.10.1",
+        "@tradetrust-tt/document-store": "^3.1.0",
+        "@tradetrust-tt/token-registry": "^4.6.0",
         "@tradetrust-tt/tradetrust": "^6.9.0",
-        "axios": "^0.21.4",
+        "axios": "^1.6.2",
         "debug": "^4.3.1",
-        "did-resolver": "^3.1.0",
-        "ethers": "^5.1.4",
-        "ethr-did-resolver": "^4.3.3",
+        "did-resolver": "^4.1.0",
+        "ethers": "^5.7.2",
+        "ethr-did-resolver": "^8.1.2",
         "node-cache": "^5.1.2",
         "runtypes": "^6.3.0",
-        "web-did-resolver": "^2.0.4"
+        "web-did-resolver": "^2.0.27"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+        "@ethersproject/abi": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+          "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
           "requires": {
-            "follow-redirects": "^1.14.0"
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+          "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+          "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+          "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0"
+          }
+        },
+        "@ethersproject/basex": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+          "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+          "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "bn.js": "^5.2.1"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+          "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+          "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0"
+          }
+        },
+        "@ethersproject/contracts": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+          "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+          "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/hdnode": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+          "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/basex": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/pbkdf2": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/wordlists": "^5.7.0"
+          }
+        },
+        "@ethersproject/json-wallets": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+          "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hdnode": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/pbkdf2": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "aes-js": "3.0.0",
+            "scrypt-js": "3.0.1"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+          "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+          "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+          "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/pbkdf2": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+          "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+          "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/providers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+          "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/basex": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0",
+            "bech32": "1.1.4",
+            "ws": "7.4.6"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+          "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+          "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+          "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+          "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "bn.js": "^5.2.1",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/solidity": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+          "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+          "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+          "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+          "requires": {
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0"
+          }
+        },
+        "@ethersproject/units": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+          "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/wallet": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+          "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/hdnode": "^5.7.0",
+            "@ethersproject/json-wallets": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/wordlists": "^5.7.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+          "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+          "requires": {
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/wordlists": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+          "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@tradetrust-tt/dnsprove": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.10.1.tgz",
+          "integrity": "sha512-C3ytoN0byLGHAMvm+rs0ErcDRAStk8o5NVUlGR8syLa/MQoXjdhMubEQo/vndytqhxipjNgKGvD0cF4G6ZTsYQ==",
+          "requires": {
+            "axios": "^1.6.3",
+            "debug": "^4.3.1",
+            "runtypes": "^6.3.0"
+          }
+        },
+        "@tradetrust-tt/document-store": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@tradetrust-tt/document-store/-/document-store-3.1.0.tgz",
+          "integrity": "sha512-iqE37xFc/m/uvg6+eUPeMfwbAiQfQp73S5oxxbnlsmObxBFwv1HW+6AuOOSgkTeaFXtWvebw2lGnOR4czwDMlg=="
+        },
+        "axios": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+          "requires": {
+            "follow-redirects": "^1.15.4",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        },
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
           }
         }
       }
@@ -4245,8 +4672,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -4335,11 +4761,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "babel-jest": {
@@ -5069,7 +5495,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "cmd-shim": {
       "version": "4.1.0",
@@ -5164,7 +5590,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5953,8 +6378,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -6009,9 +6433,9 @@
       }
     },
     "did-resolver": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.2.2.tgz",
-      "integrity": "sha512-Eeo2F524VM5N3W4GwglZrnul2y6TLTwMQP3In62JdG34NZoqihYyOZLk+5wUW8sSgvIYIcJM8Dlt3xsdKZZ3tg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
+      "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA=="
     },
     "diff": {
       "version": "4.0.2",
@@ -6791,27 +7215,296 @@
         }
       }
     },
-    "ethr-did-registry": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/ethr-did-registry/-/ethr-did-registry-0.0.3.tgz",
-      "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw=="
-    },
     "ethr-did-resolver": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-4.3.5.tgz",
-      "integrity": "sha512-BQO7PQwuqqczK+4AWQhys/sgegDVIFr6+lSoSYXlIbG0oRH0l7PkSuf7VEFKclEJ3JlJ1t9kjDIdj7Ba7euTJg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-8.1.2.tgz",
+      "integrity": "sha512-dnbE3GItE1YHp/eavR11KbGDi8Il01H9GeH+wKgoSgE95pKBZufHyHYce/EK2k8VOmj6MJf8u/TIpPvxjCbK+A==",
       "requires": {
-        "@ethersproject/abi": "^5.1.0",
-        "@ethersproject/abstract-signer": "^5.1.0",
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/basex": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/contracts": "^5.1.0",
-        "@ethersproject/providers": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0",
-        "did-resolver": "^3.1.0",
-        "ethr-did-registry": "^0.0.3",
-        "querystring": "^0.2.1"
+        "@ethersproject/abi": "^5.6.3",
+        "@ethersproject/abstract-signer": "^5.6.2",
+        "@ethersproject/address": "^5.6.1",
+        "@ethersproject/basex": "^5.6.1",
+        "@ethersproject/bignumber": "^5.6.2",
+        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/contracts": "^5.6.2",
+        "@ethersproject/keccak256": "^5.6.1",
+        "@ethersproject/providers": "^5.6.8",
+        "@ethersproject/signing-key": "^5.6.2",
+        "@ethersproject/transactions": "^5.6.2",
+        "did-resolver": "^4.0.1"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+          "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+          "requires": {
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+          "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+          "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+          "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0"
+          }
+        },
+        "@ethersproject/basex": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+          "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+          "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "bn.js": "^5.2.1"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+          "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+          "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0"
+          }
+        },
+        "@ethersproject/contracts": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+          "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+          "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+          "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+          "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+          "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+          "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/providers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+          "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/basex": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0",
+            "bech32": "1.1.4",
+            "ws": "7.4.6"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+          "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+          "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+          "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+          "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "bn.js": "^5.2.1",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+          "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+          "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+          "requires": {
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+          "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+          "requires": {
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        }
       }
     },
     "events": {
@@ -7221,9 +7914,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -9552,9 +10245,9 @@
       }
     },
     "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -10205,14 +10898,12 @@
     "mime-db": {
       "version": "1.48.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
-      "dev": true
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
     },
     "mime-types": {
       "version": "2.1.31",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
       "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "dev": true,
       "requires": {
         "mime-db": "1.48.0"
       }
@@ -11829,6 +12520,11 @@
         "read": "1"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "proxyquire": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
@@ -11888,11 +12584,6 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
-    },
-    "querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -12890,9 +13581,9 @@
       "optional": true
     },
     "shiki": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
-      "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "requires": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -14005,14 +14696,14 @@
       }
     },
     "typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.8.tgz",
+      "integrity": "sha512-mh8oLW66nwmeB9uTa0Bdcjfis+48bAjSH3uqdzSuSawfduROQLlXw//WSNZLYDdhmMVB7YcYZicq6e8T0d271A==",
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
-        "shiki": "^0.14.1"
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
       },
       "dependencies": {
         "brace-expansion": {
@@ -14029,9 +14720,9 @@
           "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
         },
         "minimatch": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -14537,31 +15228,26 @@
       }
     },
     "web-did-resolver": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.20.tgz",
-      "integrity": "sha512-qGcrm01B+ytCZUYhxH0mGOk0Ldf67kXUXLsNth6F3sx3fhUKNSIE8D+MnMFRugQm7j87mDHqUTDLmW9c90g3nw==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.27.tgz",
+      "integrity": "sha512-YxQlNdeYBXLhVpMW62+TPlc6sSOiWyBYq7DNvY6FXmXOD9g0zLeShpq2uCKFFQV/WlSrBi/yebK/W5lMTDxMUQ==",
       "requires": {
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "did-resolver": "^4.0.0"
       },
       "dependencies": {
         "cross-fetch": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+          "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
           "requires": {
-            "node-fetch": "2.6.7"
+            "node-fetch": "^2.6.12"
           }
         },
-        "did-resolver": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.0.0.tgz",
-          "integrity": "sha512-/roxrDr9EnAmLs+s9T+8+gcpilMo+IkeytcsGO7dcxvTmVJ+0Rt60HtV8o0UXHhGBo0Q+paMH/0ffXz1rqGFYg=="
-        },
         "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3053,11 +3053,11 @@
       "dev": true
     },
     "@tradetrust-tt/dnsprove": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.10.0.tgz",
-      "integrity": "sha512-Swco0gqnJ5mYnLcD2uOTo36ieA+X3GioFhVE7mhA1YXKLrF3D8k8QRFV9yTsnxu8ybmoXwJUlwmOD8w6zxtK5A==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.10.1.tgz",
+      "integrity": "sha512-C3ytoN0byLGHAMvm+rs0ErcDRAStk8o5NVUlGR8syLa/MQoXjdhMubEQo/vndytqhxipjNgKGvD0cF4G6ZTsYQ==",
       "requires": {
-        "axios": "^0.21.1",
+        "axios": "^1.6.3",
         "debug": "^4.3.1",
         "runtypes": "^6.3.0"
       }
@@ -4761,11 +4761,25 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "babel-jest": {
@@ -5495,7 +5509,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "cmd-shim": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ajv-formats": "^2.1.0",
     "chalk": "^4.1.2",
     "debug": "^4.3.2",
-    "ethers": "^5.4.7",
+    "ethers": "^5.7.2",
     "ethers-aws-kms-signer": "^1.3.2",
     "inquirer": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@govtechsg/oa-encryption": "^1.3.3",
     "@snyk/protect": "^1.1196.0",
-    "@tradetrust-tt/dnsprove": "^2.10.0",
+    "@tradetrust-tt/dnsprove": "^2.10.1",
     "@tradetrust-tt/document-store": "^2.7.0",
     "@tradetrust-tt/token-registry": "^4.6.0",
     "@tradetrust-tt/tradetrust": "^6.9.0",
@@ -165,7 +165,7 @@
     ],
     "testTimeout": 20000,
     "moduleNameMapper": {
-      "^axios": "<rootDir>/node_modules/axios"
+      "axios": "axios/dist/node/axios.cjs"
     }
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -70,13 +70,13 @@
   },
   "dependencies": {
     "@govtechsg/oa-encryption": "^1.3.3",
-    "@tradetrust-tt/tradetrust-config": "^1.5.1",
     "@snyk/protect": "^1.1196.0",
-    "@tradetrust-tt/dnsprove": "^2.8.1",
-    "@tradetrust-tt/document-store": "^2.6.1",
-    "@tradetrust-tt/token-registry": "^4.5.0",
+    "@tradetrust-tt/dnsprove": "^2.10.0",
+    "@tradetrust-tt/document-store": "^2.7.0",
+    "@tradetrust-tt/token-registry": "^4.6.0",
     "@tradetrust-tt/tradetrust": "^6.9.0",
-    "@tradetrust-tt/tt-verify": "^8.4.0",
+    "@tradetrust-tt/tradetrust-config": "^1.11.0",
+    "@tradetrust-tt/tt-verify": "^8.7.0",
     "ajv": "^8.4.0",
     "ajv-formats": "^2.1.0",
     "chalk": "^4.1.2",
@@ -163,7 +163,10 @@
       "jest-watch-typeahead/filename",
       "jest-watch-typeahead/testname"
     ],
-    "testTimeout": 20000
+    "testTimeout": 20000,
+    "moduleNameMapper": {
+      "^axios": "<rootDir>/node_modules/axios"
+    }
   },
   "prettier": {
     "printWidth": 120

--- a/src/commands/config/config.type.ts
+++ b/src/commands/config/config.type.ts
@@ -14,4 +14,5 @@ export enum TestNetwork {
   Mumbai = "mumbai (polygon)",
   Apothem = "apothem (xdc)",
   Hedera = "hedera (testnet)",
+  StabilityTestnet = "stability (testnet)",
 }

--- a/src/commands/config/create.ts
+++ b/src/commands/config/create.ts
@@ -91,6 +91,7 @@ const convertNetworkToNetworkCmdName = (selectedNetwork: TestNetwork): NetworkCm
     [TestNetwork.Mumbai]: NetworkCmdName.Maticmum,
     [TestNetwork.Apothem]: NetworkCmdName.XDCApothem,
     [TestNetwork.Hedera]: NetworkCmdName.HederaTestnet,
+    [TestNetwork.StabilityTestnet]: NetworkCmdName.StabilityTestnet,
   };
   return network[selectedNetwork];
 };

--- a/src/commands/config/create.ts
+++ b/src/commands/config/create.ts
@@ -66,6 +66,7 @@ export const handler = async (args: CreateConfigCommand): Promise<void> => {
       TestNetwork.Mumbai,
       TestNetwork.Apothem,
       TestNetwork.Hedera,
+      TestNetwork.StabilityTestnet,
     ];
     const { network } = await inquirer.prompt({
       type: "list",

--- a/src/common/networks.ts
+++ b/src/common/networks.ts
@@ -2,7 +2,7 @@ import { providers } from "ethers";
 import type { GasStationFunction } from "./gas-station";
 import { gasStation } from "./gas-station";
 
-export type networkCurrency = "ETH" | "MATIC" | "XDC" | "HBAR";
+export type networkCurrency = "ETH" | "MATIC" | "XDC" | "HBAR" | "FREE";
 
 type SupportedNetwork = {
   explorer: string;
@@ -23,6 +23,7 @@ export enum NetworkCmdName {
   XDCApothem = "xdcapothem",
   HederaMainnet = "hederamainnet",
   HederaTestnet = "hederatestnet",
+  StabilityTestnet = "stabilitytestnet",
 }
 
 const defaultInfuraProvider =
@@ -102,6 +103,13 @@ export const supportedNetwork: {
     networkId: 296,
     networkName: NetworkCmdName.HederaTestnet,
     currency: "HBAR",
+  },
+  [NetworkCmdName.StabilityTestnet]: {
+    explorer: "https://stability-testnet.blockscout.com/",
+    provider: jsonRpcProvider("https://free.testnet.stabilityprotocol.com"),
+    networkId: 20180427,
+    networkName: NetworkCmdName.StabilityTestnet,
+    currency: "FREE",
   },
 };
 

--- a/src/implementations/wallet/__tests__/create.test.ts
+++ b/src/implementations/wallet/__tests__/create.test.ts
@@ -26,7 +26,7 @@ describe("create wallet", () => {
       expect.objectContaining({
         address: expect.any(String),
         id: expect.any(String),
-        Crypto: {
+        crypto: {
           cipher: "aes-128-ctr",
           cipherparams: {
             iv: expect.any(String),

--- a/src/implementations/wallet/__tests__/encrypt.test.ts
+++ b/src/implementations/wallet/__tests__/encrypt.test.ts
@@ -35,7 +35,7 @@ describe("create wallet", () => {
       expect.objectContaining({
         address: expect.any(String),
         id: expect.any(String),
-        Crypto: {
+        crypto: {
           cipher: "aes-128-ctr",
           cipherparams: {
             iv: expect.any(String),


### PR DESCRIPTION
## Summary

This PR adds support for [Stability Testnet](https://github.com/stabilityprotocol/) network.

This PR is pending other PR related to the TradeTrust pkg to update the `package.json` dependency: https://github.com/TradeTrust/token-registry/pull/4

## Changes
* Networks

## Issues
NA

For further information, please reach the following email: kerk@stabilityprotocol.com