### PR TITLE
fix: xdc apothem rpc url

### DIFF
--- a/src/common/networks.ts
+++ b/src/common/networks.ts
@@ -86,7 +86,7 @@ export const supportedNetwork: {
   },
   [NetworkCmdName.XDCApothem]: {
     explorer: "https://apothem.xdcscan.io",
-    provider: jsonRpcProvider("https://rpc.ankr.com/xdc_testnet"),
+    provider: jsonRpcProvider("https://rpc.apothem.network"),
     networkId: 51,
     networkName: NetworkCmdName.XDCApothem,
     currency: "XDC",


### PR DESCRIPTION
## Summary

Update XDC apothem rpc url due to the one we are using is not working.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the XDCApothem testnet RPC endpoint configuration to enhance network connectivity and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->